### PR TITLE
Fixed dscl call w/ variable instead of hard value

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -24,7 +24,7 @@ function create_user() {
 	# see if user exists
 	if dscl /Local/Default list /Users | grep -q ${SERVICE_USER} ; then
 		echo "Using pre-existing service account ${SERVICE_USER}"
-		SERVICE_HOME=`dscl /Local/Default read /Users/Jenkins NFSHomeDirectory | awk '{print $2}'`
+		SERVICE_HOME=`dscl /Local/Default read /Users/${SERVICE_USER}" NFSHomeDirectory | awk '{print $2}'`
 		return 0
 	fi
 	echo "Creating service account ${SERVICE_USER}..."


### PR DESCRIPTION
When the user exists and you use dscl to fetch the NFSHomeDirectory, you should use the variable `$SERVICE_USER` instead of the hard value `Jenkins` in case the user did not user the default value.
